### PR TITLE
Fix typo in .service file

### DIFF
--- a/packaging/files/lora-packet-multiplexer.service
+++ b/packaging/files/lora-packet-multiplexer.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 User=packetmultiplexer
 Group=packetmultiplexer
-ExecStart=/usr/bin/lora-packet-Multiplexer
+ExecStart=/usr/bin/lora-packet-multiplexer
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
This corrects the name of the executable, allowing the service to be started.